### PR TITLE
Update video-embed-thumbnail-generator.php

### DIFF
--- a/video-embed-thumbnail-generator.php
+++ b/video-embed-thumbnail-generator.php
@@ -3777,7 +3777,7 @@ function kgvid_update_settings() {
 				delete_option($old_setting);
 			}
 		}
-		$wpdb->query( $wpdb->prepare("DELETE FROM $wpdb->options WHERE option_name LIKE 'wp_FMP%'") );
+		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'wp_FMP%'" );
 
 		foreach ( $default_options as $key => $value ) { //apply default values for any settings that didn't exist before
 			if ( !array_key_exists($key, $options) ) { $options[$key] = $value; }


### PR DESCRIPTION
removes an unneccessary wp-prepare which was causing warnings (since WP 3.5 prepare needs two arguments - just passing one triggers a warning and effectively serves no purpose).

"Warning: prepare() expects exactly 2 parameters, 1 given in /var/www/vmrom.info/public_html/wp-includes/wp-db.php on line 1153"
